### PR TITLE
Renaming functions for better code readability

### DIFF
--- a/proof.dfy
+++ b/proof.dfy
@@ -81,7 +81,6 @@ module Proof {
   }
 
   function sendersOf(msgs:set<Messages.Message>) : set<HostIdentifiers.HostId> {
-    //set sender | sender in AllHosts() && (exists msg | msg in msgs :: msg.sender == sender)
     set msg | msg in msgs :: msg.sender
   }
 


### PR DESCRIPTION
Changed two function names, to make them read more like human sentences. With the new names, we have for example:
- sendersOf(prepares)
- sendersOf(sentPreparesForSeqId())
- ...

I think this also makes the proof easier to understand and more self-documenting.

PS: I also removed a redundant (outdated?) comment in one of the functions.