### PR TITLE
Proof commit agreement in honest replicas

### DIFF
--- a/cluster_config.s.dfy
+++ b/cluster_config.s.dfy
@@ -1,4 +1,7 @@
+include "network.s.dfy"
+
 module ClusterConfig {
+  import opened HostIdentifiers
 
   datatype Constants = Constants(
     maxByzantineFaultyReplicas:nat,
@@ -39,6 +42,20 @@ module ClusterConfig {
       requires WF()
     {
       2 * F() + 1
+    }
+
+    predicate IsReplica(id:HostId)
+      requires WF()
+    {
+      && ValidHostId(id)
+      && 0 <= id < N()
+    }
+
+    predicate IsClient(id:HostId)
+      requires WF()
+    {
+      && ValidHostId(id)
+      && N() <= id < NumHosts()
     }
   }
 }

--- a/proof.dfy
+++ b/proof.dfy
@@ -548,11 +548,7 @@ module Proof {
     requires SentCommitIsEnabled(c, v, v', step, h_step)
     ensures Inv(c, v')
   {
-    ProofEveryCommitMsgIsSupportedByAQuorumOfPrepares(c, v, v', step);
-    reveal_EveryCommitClientOpMatchesRecordedPrePrepare();
-    reveal_RecordedCommitsClientOpsMatchPrePrepare();
-    reveal_EveryCommitIsSupportedByRecordedPrepares();
-    HonestReplicasLockOnCommitForGivenViewLemma(c, v, v', step, h_step);
+    CommitMsgStability(c, v, v', step);
     forall commitMsg | && commitMsg in v'.network.sentMsgs 
                        && commitMsg.Commit? 
                        && IsHonestReplica(c, commitMsg.sender)
@@ -562,6 +558,7 @@ module Proof {
           var h_v := v.hosts[step.id].replicaVariables;
           var senders := h_v.workingWindow.preparesRcvd[commitMsg.seqID].Keys;
           var senders' := sendersOf(sentPreparesForSeqID(c, v', commitMsg.seqID, commitMsg.clientOp));
+          assert forall sender | sender in senders :: sender in senders'; //Trigger.
           Library.SubsetCardinality(senders, senders');
         }
       }

--- a/proof.dfy
+++ b/proof.dfy
@@ -62,6 +62,10 @@ module Proof {
           :: QuorumOfPreparesInNetwork(c, v, commitMsg.view, commitMsg.seqID, commitMsg.clientOp) )
   }
 
+  // This predicate states that honest replicas accept the first PrePrepare they receive and vote
+  // with a Prepare message only for it. The lock on Prepare is meant to highlight the fact that
+  // even though a replica can send multiple times a Prepare message for a given Sequence ID for
+  // a given View, this message will not change unless a View Change happens.
   predicate HonestReplicasLockOnPrepareForGivenView(c: Constants, v:Variables)
   {
     && (forall msg1, msg2 | 
@@ -76,6 +80,9 @@ module Proof {
         :: msg1 == msg2)
   }
 
+  // This predicate states that if a replica sends a Commit message for a given Sequence ID for a given View
+  // it will not change its mind, even if it re-sends this message multiple times it will always be the same
+  // for a given View.
   predicate {:opaque} HonestReplicasLockOnCommitForGivenView(c:Constants, v:Variables) {
     && (forall msg1, msg2 | 
         && msg1 in v.network.sentMsgs 

--- a/replica.i.dfy
+++ b/replica.i.dfy
@@ -16,13 +16,17 @@ module Replica {
   import ClusterConfig
                      
   type PrepareProofSet = map<HostId, Message> 
-  predicate PrepareProofSetWF(c:Constants, ps:PrepareProofSet) {
+  predicate PrepareProofSetWF(c:Constants, ps:PrepareProofSet)
+    requires c.WF()
+  {
       && forall x | x in ps :: && ps[x].Prepare? 
                                && c.clusterConfig.IsReplica(ps[x].sender)
   }
 
   type CommitProofSet = map<HostId, Message>
-  predicate CommitProofSetWF(c:Constants, cs:CommitProofSet) {
+  predicate CommitProofSetWF(c:Constants, cs:CommitProofSet)
+    requires c.WF()
+  {
       && forall x | x in cs :: && cs[x].Commit?
                                && c.clusterConfig.IsReplica(cs[x].sender)
   }
@@ -44,6 +48,7 @@ module Replica {
     commitsRcvd:imap<SequenceID, CommitProofSet>
   ) {
     predicate WF(c:Constants)
+      requires c.WF()
     {
       && FullImap(committedClientOperations)
       && FullImap(preparesRcvd)


### PR DESCRIPTION
In this MR we have a complete proof that honest Replicas place the same Client operation in their Commit message for a given Sequence ID for the View they are in.