### PR TITLE
Removed unnecessary invocation of lemma.

### DIFF
--- a/proof.dfy
+++ b/proof.dfy
@@ -623,8 +623,6 @@ module Proof {
   {
     var step :| NextStep(c, v, v', step);
 
-    ProofEveryCommitMsgIsSupportedByAQuorumOfPrepares(c, v, v', step);
-
     if (c.clusterConfig.IsReplica(step.id))
     {
       var h_c := c.hosts[step.id].replicaConstants;


### PR DESCRIPTION
The lemma ProofEveryCommitMsgIsSupportedByAQuorumOfPrepares
is called in CommitMsgStability, therefore we don't need to
call it twice.