### PR TITLE
View change model

### DIFF
--- a/library/Library.dfy
+++ b/library/Library.dfy
@@ -81,13 +81,6 @@ module Library {
      requires x in s
      requires |s| == 1
      ensures s == {x}
-  {
-    forall y | y in s ensures y in {x} {
-      if y!=x { // contradiction proof
-        SubsetCardinality({x,y}, s);
-      }
-    }
-  }
 
   // Warning: Dafny automation black magic.
   // Everything is in a FullImap! But sometimes Dafny seems unable

--- a/library/Library.dfy
+++ b/library/Library.dfy
@@ -77,6 +77,18 @@ module Library {
     forall k :: k in im
   }
 
+  lemma SingletonSetAxiom<T>(x:T, s:set<T>) 
+     requires x in s
+     requires |s| == 1
+     ensures s == {x}
+  {
+    forall y | y in s ensures y in {x} {
+      if y!=x { // contradiction proof
+        SubsetCardinality({x,y}, s);
+      }
+    }
+  }
+
   // Warning: Dafny automation black magic.
   // Everything is in a FullImap! But sometimes Dafny seems unable
   // to trigger that forall. (jonh suspects the issue is related to

--- a/messages.dfy
+++ b/messages.dfy
@@ -24,10 +24,13 @@ module Messages {
       var prot :| prot in votes;
       prot.payload
     }
+    predicate WF() {
+      (forall v | v in votes :: v.payload.Prepare?)
+    }
     predicate valid(quorumSize:nat) {
       || empty()
       || (&& |votes| == quorumSize
-          && prototype().Prepare?
+          && WF()
           && (forall v | v in votes :: v.payload == prototype()) // messages have to be votes that match eachother by the prototype 
           && (forall v1, v2 | && v1 in votes
                               && v2 in votes

--- a/messages.dfy
+++ b/messages.dfy
@@ -32,7 +32,7 @@ module Messages {
                      | Prepare(view:ViewNum, seqID:SequenceID, clientOp:ClientOperation)
                      | Commit(view:ViewNum, seqID:SequenceID, clientOp:ClientOperation)
                      | ClientRequest(clientOp:ClientOperation)
-                     | ViewChangeMsg(newView:ViewNum, certificates:map<SequenceID, PreparedCertificate>) // omitting last stable because we don't have checkpointing yet.
+                     | ViewChangeMsg(newView:ViewNum, certificates:imap<SequenceID, PreparedCertificate>) // omitting last stable because we don't have checkpointing yet.
 
   // ToDo: ClientReply
 }

--- a/messages.dfy
+++ b/messages.dfy
@@ -9,10 +9,17 @@ module Messages {
 
   datatype ClientOperation = ClientOperation(sender:HostId, timestamp:nat)
 
-  datatype PreparedCertificate = PreparedCertificate(prototype: Message, votes:set<Network.Message<Message>>) {
+  datatype PreparedCertificate = PreparedCertificate(votes:set<Network.Message<Message>>) {
+    function prototype() : Message 
+      requires |votes| > 0
+    {
+      var prot :| prot in votes;
+      prot.payload
+    }
     predicate valid() {
-      && prototype.Prepare?
-      && (forall v | v in votes :: v.payload == prototype) // messages have to be votes that match eachother by the prototype 
+      && |votes| > 0
+      && prototype().Prepare?
+      && (forall v | v in votes :: v.payload == prototype()) // messages have to be votes that match eachother by the prototype 
       && (forall v1, v2 | && v1 in votes
                           && v2 in votes
                           && v1 != v2

--- a/messages.dfy
+++ b/messages.dfy
@@ -1,6 +1,8 @@
 include "network.s.dfy"
+include "library/Library.dfy"
 
 module Messages {
+  import Library
   import opened HostIdentifiers
   import Network
 
@@ -9,27 +11,30 @@ module Messages {
 
   datatype ClientOperation = ClientOperation(sender:HostId, timestamp:nat)
 
+  datatype OperationWrapper = Noop | ClientOp(clientOperation: ClientOperation)
+
   function sendersOf(msgs:set<Network.Message<Message>>) : set<HostIdentifiers.HostId> {
     set msg | msg in msgs :: msg.sender
   }
 
-  datatype PreparedCertificate = PreparedCertificate(votes:set<Network.Message<Message>>) {
-    function prototype() : Message 
-      requires |votes| > 0
-    {
-      var prot :| prot in votes;
-      prot.payload
-    }
+  datatype PreparedCertificate = PreparedCertificate(view:ViewNum,
+                                                     operationFromPastView:OperationWrapper,
+                                                     votes:set<Network.Message<Message>>) {
     predicate valid(quorumSize:nat) {
-      || empty()
-      || (&& |votes| == quorumSize
-          && prototype().Prepare?
-          && (forall v | v in votes :: v.payload == prototype()) // messages have to be votes that match eachother by the prototype 
-          && (forall v1, v2 | && v1 in votes
-                              && v2 in votes
-                              && v1 != v2
-                                :: v1.sender != v2.sender) // unique senders
-          )
+      || ( && empty() 
+           && operationFromPastView.Noop? )
+      || ( && |votes| == quorumSize
+           && (forall v1, v2 | && v1 in votes
+                               && v2 in votes
+                               && v1 != v2
+                                 :: v1.sender != v2.sender) // unique senders
+           && (forall v1, v2 | && v1 in votes
+                               && v2 in votes
+                                 :: v1.payload == v2.payload) // messages have to be votes that match eachother
+           && (forall v | v in votes 
+                          :: && v.payload.Prepare?
+                             && view == v.payload.view  
+                             && operationFromPastView == ClientOp(v.payload.clientOp)))
     }
     predicate empty() {
       && |votes| == 0
@@ -39,7 +44,8 @@ module Messages {
   datatype ViewChangeMsgsSelectedByPrimary = ViewChangeMsgsSelectedByPrimary(msgs:set<Network.Message<Message>>) {
     predicate valid(view:ViewNum, quorumSize:nat) {
       && |msgs| > 0
-      && (forall v | v in msgs :: && v.payload.ViewChangeMsg? 
+      && (forall v | v in msgs :: && v.payload.ViewChangeMsg?
+                                  && v.payload.WF()
                                   && v.payload.newView == view) // All the ViewChange messages have to be for the same View. 
       && (forall v1, v2 | && v1 in msgs
                           && v2 in msgs
@@ -55,6 +61,10 @@ module Messages {
                      | Commit(view:ViewNum, seqID:SequenceID, clientOp:ClientOperation)
                      | ClientRequest(clientOp:ClientOperation)
                      | ViewChangeMsg(newView:ViewNum, certificates:imap<SequenceID, PreparedCertificate>) // omitting last stable because we don't have checkpointing yet.
-                     | NewViewMsg(newView:ViewNum, vcMsgs:ViewChangeMsgsSelectedByPrimary)
+                     | NewViewMsg(newView:ViewNum, vcMsgs:ViewChangeMsgsSelectedByPrimary) {
+                       predicate WF() {
+                         && (ViewChangeMsg? ==> Library.FullImap(certificates))
+                       }
+                     }
   // ToDo: ClientReply
 }

--- a/messages.dfy
+++ b/messages.dfy
@@ -39,7 +39,7 @@ module Messages {
                           && v2 in msgs
                           && v1 != v2
                             :: v1.sender != v2.sender) // unique senders
-      && |msgs| >= quorumSize
+      && |msgs| == quorumSize
     }
   }
 

--- a/messages.dfy
+++ b/messages.dfy
@@ -25,6 +25,9 @@ module Messages {
                           && v1 != v2
                             :: v1.sender != v2.sender) // unique senders
     }
+    predicate empty() {
+      && |votes| == 0
+    }
   }
 
   // Define your Message datatype here.

--- a/messages.dfy
+++ b/messages.dfy
@@ -9,6 +9,10 @@ module Messages {
 
   datatype ClientOperation = ClientOperation(sender:HostId, timestamp:nat)
 
+  function sendersOf(msgs:set<Network.Message<Message>>) : set<HostIdentifiers.HostId> {
+    set msg | msg in msgs :: msg.sender
+  }
+
   datatype PreparedCertificate = PreparedCertificate(votes:set<Network.Message<Message>>) {
     function prototype() : Message 
       requires |votes| > 0
@@ -16,14 +20,16 @@ module Messages {
       var prot :| prot in votes;
       prot.payload
     }
-    predicate valid() {
-      && |votes| > 0
-      && prototype().Prepare?
-      && (forall v | v in votes :: v.payload == prototype()) // messages have to be votes that match eachother by the prototype 
-      && (forall v1, v2 | && v1 in votes
-                          && v2 in votes
-                          && v1 != v2
-                            :: v1.sender != v2.sender) // unique senders
+    predicate valid(quorumSize:nat) {
+      || empty()
+      || (&& |votes| == quorumSize
+          && prototype().Prepare?
+          && (forall v | v in votes :: v.payload == prototype()) // messages have to be votes that match eachother by the prototype 
+          && (forall v1, v2 | && v1 in votes
+                              && v2 in votes
+                              && v1 != v2
+                                :: v1.sender != v2.sender) // unique senders
+          )
     }
     predicate empty() {
       && |votes| == 0

--- a/messages.dfy
+++ b/messages.dfy
@@ -11,6 +11,8 @@ module Messages {
 
   datatype ClientOperation = ClientOperation(sender:HostId, timestamp:nat)
 
+  datatype OperationWrapper = Noop | ClientOp(clientOperation: ClientOperation)
+
   function sendersOf(msgs:set<Network.Message<Message>>) : set<HostIdentifiers.HostId> {
     set msg | msg in msgs :: msg.sender
   }
@@ -53,9 +55,9 @@ module Messages {
   }
 
   // Define your Message datatype here.
-  datatype Message = | PrePrepare(view:ViewNum, seqID:SequenceID, clientOp:ClientOperation)
-                     | Prepare(view:ViewNum, seqID:SequenceID, clientOp:ClientOperation)
-                     | Commit(view:ViewNum, seqID:SequenceID, clientOp:ClientOperation)
+  datatype Message = | PrePrepare(view:ViewNum, seqID:SequenceID, operationWrapper:OperationWrapper)
+                     | Prepare(view:ViewNum, seqID:SequenceID, operationWrapper:OperationWrapper)
+                     | Commit(view:ViewNum, seqID:SequenceID, operationWrapper:OperationWrapper)
                      | ClientRequest(clientOp:ClientOperation)
                      | ViewChangeMsg(newView:ViewNum, certificates:imap<SequenceID, PreparedCertificate>) // omitting last stable because we don't have checkpointing yet.
                      | NewViewMsg(newView:ViewNum, vcMsgs:ViewChangeMsgsSelectedByPrimary) {

--- a/messages.dfy
+++ b/messages.dfy
@@ -30,12 +30,25 @@ module Messages {
     }
   }
 
+  datatype ViewChangeMsgsSelectedByPrimary = ViewChangeMsgsSelectedByPrimary(msgs:set<Network.Message<Message>>) {
+    predicate valid(view:ViewNum, quorumSize:nat) {
+      && |msgs| > 0
+      && (forall v | v in msgs :: && v.payload.ViewChangeMsg? 
+                                  && v.payload.newView == view) // All the ViewChange messages have to be for the same View. 
+      && (forall v1, v2 | && v1 in msgs
+                          && v2 in msgs
+                          && v1 != v2
+                            :: v1.sender != v2.sender) // unique senders
+      && |msgs| >= quorumSize
+    }
+  }
+
   // Define your Message datatype here.
   datatype Message = | PrePrepare(view:ViewNum, seqID:SequenceID, clientOp:ClientOperation)
                      | Prepare(view:ViewNum, seqID:SequenceID, clientOp:ClientOperation)
                      | Commit(view:ViewNum, seqID:SequenceID, clientOp:ClientOperation)
                      | ClientRequest(clientOp:ClientOperation)
                      | ViewChangeMsg(newView:ViewNum, certificates:imap<SequenceID, PreparedCertificate>) // omitting last stable because we don't have checkpointing yet.
-
+                     | NewViewMsg(newView:ViewNum, vcMsgs:ViewChangeMsgsSelectedByPrimary)
   // ToDo: ClientReply
 }

--- a/proof.dfy
+++ b/proof.dfy
@@ -207,8 +207,16 @@ module Proof {
   //                                       :: prePrepare1 == prePrepare2)
   // }
 
+  predicate AllReplicasLiteInv (c: Constants, v:Variables) {
+    && v.WF(c)
+    && (forall replicaIdx | 0 <= replicaIdx < |c.hosts| && c.clusterConfig.IsReplica(replicaIdx)
+                            :: Replica.LiteInv(c.hosts[replicaIdx].replicaConstants, v.hosts[replicaIdx].replicaVariables))
+  }
+
   predicate Inv(c: Constants, v:Variables) {
     //&& PrePreparesCarrySameClientOpsForGivenSeqID(c, v)
+    // Do not remove, lite invariant about internal honest Node invariants:
+    && AllReplicasLiteInv(c, v)
     && RecordedPreparesHaveValidSenderID(c, v)
     && SentPreparesMatchRecordedPrePrepareIfHostInSameView(c, v)
     && RecordedPrePreparesRecvdCameFromNetwork(c, v)

--- a/replica.i.dfy
+++ b/replica.i.dfy
@@ -98,13 +98,18 @@ module Replica {
   }
 
   function CurrentPrimary(c:Constants, v:Variables) : nat 
-    requires c.WF()
+    requires v.WF(c)
   {
     v.view % c.clusterConfig.N()
   }
 
-  predicate HaveSufficientVCMsgsToMoveTo(c:Constants, v:Variables, newView:ViewNum) {
-    false
+  predicate HaveSufficientVCMsgsToMoveTo(c:Constants, v:Variables, newView:ViewNum)
+    requires v.WF(c)
+  {
+    && var relevantVCMsgs := set vcMsg | && vcMsg in v.viewChangeMsgsRecvd.msgs 
+                                         && vcMsg.payload.newView >= newView;
+    && |relevantVCMsgs| >= c.clusterConfig.ByzantineSafeQuorum() //F+1
+    && (exists vcMsg :: vcMsg in relevantVCMsgs && vcMsg.payload.newView == newView)
   }
 
   predicate ViewIsActive(c:Constants, v:Variables) {

--- a/replica.i.dfy
+++ b/replica.i.dfy
@@ -344,6 +344,8 @@ module Replica {
     | DoCommitStep(seqID:SequenceID)
     //| Execute(seqID:SequenceID)
     //| SendReplyToClient(seqID:SequenceID)
+    | LeaveViewStep(newView:ViewNum)
+    | SendViewChangeMsgStep()
 
   predicate NextStep(c:Constants, v:Variables, v':Variables, msgOps:Network.MessageOps<Message>, step: Step) {
     match step
@@ -354,6 +356,8 @@ module Replica {
        case SendCommitStep(seqID) => SendCommit(c, v, v', msgOps, seqID)
        case RecvCommitStep() => RecvCommit(c, v, v', msgOps)
        case DoCommitStep(seqID) => DoCommit(c, v, v', msgOps, seqID)
+       case LeaveViewStep(newView) => LeaveView(c, v, v', msgOps, newView)
+       case SendViewChangeMsgStep() => SendViewChangeMsg(c, v, v', msgOps)
   }
 
   predicate Next(c:Constants, v:Variables, v':Variables, msgOps:Network.MessageOps<Message>) {

--- a/replica.i.dfy
+++ b/replica.i.dfy
@@ -372,6 +372,7 @@ module Replica {
   }
 
   predicate LeaveView(c:Constants, v:Variables, v':Variables, msgOps:Network.MessageOps<Message>, newView:ViewNum) {
+    // TODO: Clear all Working Window after we leave a View.
     && v.WF(c)
     && msgOps.NoSendRecv()
     // We can only leave a view we have collected at least 2F+1 View 
@@ -491,12 +492,13 @@ module Replica {
     | DoCommitStep(seqID:SequenceID)
     //| Execute(seqID:SequenceID)
     //| SendReplyToClient(seqID:SequenceID)
-    | LeaveViewStep(newView:ViewNum)
-    | SendViewChangeMsgStep()
-    | RecvViewChangeMsgStep()
-    | SelectQuorumOfViewChangeMsgsStep(viewChangeMsgsSelectedByPrimary:ViewChangeMsgsSelectedByPrimary)
-    | SendNewViewMsgStep()
-    | RecvNewViewMsgStep()
+    // TODO: uncomment those steps when we start working on the proof
+    // | LeaveViewStep(newView:ViewNum)
+    // | SendViewChangeMsgStep()
+    // | RecvViewChangeMsgStep()
+    // | SelectQuorumOfViewChangeMsgsStep(viewChangeMsgsSelectedByPrimary:ViewChangeMsgsSelectedByPrimary)
+    // | SendNewViewMsgStep()
+    // | RecvNewViewMsgStep()
 
   predicate NextStep(c:Constants, v:Variables, v':Variables, msgOps:Network.MessageOps<Message>, step: Step) {
     match step
@@ -507,12 +509,13 @@ module Replica {
        case SendCommitStep(seqID) => SendCommit(c, v, v', msgOps, seqID)
        case RecvCommitStep() => RecvCommit(c, v, v', msgOps)
        case DoCommitStep(seqID) => DoCommit(c, v, v', msgOps, seqID)
-       case LeaveViewStep(newView) => LeaveView(c, v, v', msgOps, newView)
-       case SendViewChangeMsgStep() => SendViewChangeMsg(c, v, v', msgOps)
-       case RecvViewChangeMsgStep() => RecvViewChangeMsg(c, v, v', msgOps)
-       case SelectQuorumOfViewChangeMsgsStep(viewChangeMsgsSelectedByPrimary) => SelectQuorumOfViewChangeMsgs(c, v, v', msgOps, viewChangeMsgsSelectedByPrimary)
-       case SendNewViewMsgStep() => SendNewViewMsg(c, v, v', msgOps)
-       case RecvNewViewMsgStep() => RecvNewViewMsg(c, v, v', msgOps)
+       // TODO: uncomment those steps when we start working on the proof
+       // case LeaveViewStep(newView) => LeaveView(c, v, v', msgOps, newView)
+       // case SendViewChangeMsgStep() => SendViewChangeMsg(c, v, v', msgOps)
+       // case RecvViewChangeMsgStep() => RecvViewChangeMsg(c, v, v', msgOps)
+       // case SelectQuorumOfViewChangeMsgsStep(viewChangeMsgsSelectedByPrimary) => SelectQuorumOfViewChangeMsgs(c, v, v', msgOps, viewChangeMsgsSelectedByPrimary)
+       // case SendNewViewMsgStep() => SendNewViewMsg(c, v, v', msgOps)
+       // case RecvNewViewMsgStep() => RecvNewViewMsg(c, v, v', msgOps)
   }
 
   predicate Next(c:Constants, v:Variables, v':Variables, msgOps:Network.MessageOps<Message>) {

--- a/replica.i.dfy
+++ b/replica.i.dfy
@@ -108,7 +108,6 @@ module Replica {
     && var relevantVCMsgs := set vcMsg | && vcMsg in v.viewChangeMsgsRecvd.msgs 
                                          && vcMsg.payload.newView >= newView;
     && |relevantVCMsgs| >= c.clusterConfig.ByzantineSafeQuorum() //F+1
-    && (exists vcMsg :: vcMsg in relevantVCMsgs && vcMsg.payload.newView == newView)
   }
 
   predicate HasCollectedProofMyViewIsAgreed(c:Constants, v:Variables) {
@@ -128,7 +127,6 @@ module Replica {
     && var haveMyVCMsg := exists myVCMsg :: && myVCMsg in v.viewChangeMsgsRecvd.msgs
                                             && myVCMsg.sender == c.myId
                                             && myVCMsg.payload.newView == v.view;
-    && |vcMsgsForHigherView| < c.clusterConfig.ByzantineSafeQuorum() //F+1
     && ( || v.view == 0 // View 0 is active initially. There are no View Change messages for it.
          || (haveMyVCMsg && |vcMsgsForMyView| >= c.clusterConfig.AgreementQuorum())) //2F+1
     // TODO: take in account NewViewMsg once we have it in the model


### PR DESCRIPTION
Initial version of the View Change mechanism.
Modeled leaving of a view in Replicas and generating and sending the corresponding View Change msg.
Modeled the sending of the New View msg from the new primary in a view.
Modeled the calculation of the restrictions of the previous view's working window after the view change.